### PR TITLE
fix: travis 2: electric boogaloo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before-deploy:
 - eval "$(ssh-agent -s)"
 - chmod 600 /tmp/deploy_rsa
 - ssh-add /tmp/deploy_rsa
+- cd ..
 deploy:
   provider: script
   script: bash scripts/deploy.sh


### PR DESCRIPTION
`cd` back into root directory before running deploy script